### PR TITLE
Restore compatibility with older versions of Rust

### DIFF
--- a/src/reading.rs
+++ b/src/reading.rs
@@ -207,7 +207,7 @@ impl PageParser {
 				packet_positions : Vec::new(),
 				ends_with_continued : false,
 			},
-			stream_serial,
+			stream_serial : stream_serial,
 			checksum : header_rdr.read_u32::<LittleEndian>().unwrap(),
 			header_buf : header_buf,
 			packet_count : 0,


### PR DESCRIPTION
Newer versions of Rust allow omitting the field name if it is equal to the variable name. This feature was stabilized in Rust 1.17. By including the field name again, this restores compatibility with Rust versions at least as old as 1.13 (I did not try older versions). For such a small change, the compatibility win seems worth the extra bytes.