### PR TITLE
Do not verify checksum during fuzzing

### DIFF
--- a/src/reading.rs
+++ b/src/reading.rs
@@ -282,7 +282,7 @@ impl PageParser {
 		hash_calculated = vorbis_crc32_update(hash_calculated, &packet_data);
 
 		// 3. Compare to the extracted one
-		if self.checksum != hash_calculated {
+		if (! cfg!(fuzzing)) && self.checksum != hash_calculated {
 			try!(Err(OggReadError::HashMismatch(self.checksum, hash_calculated)));
 		}
 		self.segments_or_packets_buf = packet_data;

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -282,7 +282,8 @@ impl PageParser {
 		hash_calculated = vorbis_crc32_update(hash_calculated, &packet_data);
 
 		// 3. Compare to the extracted one
-		if (! cfg!(fuzzing)) && self.checksum != hash_calculated {
+		if self.checksum != hash_calculated {
+			#[cfg(not(fuzzing))]
 			try!(Err(OggReadError::HashMismatch(self.checksum, hash_calculated)));
 		}
 		self.segments_or_packets_buf = packet_data;

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -283,6 +283,9 @@ impl PageParser {
 
 		// 3. Compare to the extracted one
 		if self.checksum != hash_calculated {
+			// Do not verify checksum when the decoder is being fuzzed.
+			// This allows random input from fuzzers reach decoding code that's actually interesting,
+			// instead of being rejected early due to checksum mismatch.
 			#[cfg(not(fuzzing))]
 			try!(Err(OggReadError::HashMismatch(self.checksum, hash_calculated)));
 		}


### PR DESCRIPTION
Allows meaningful fuzzing of ogg and lewton crates via rust-fuzz tooling ([afl.rs](https://github.com/rust-fuzz/afl.rs), [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz), [honggfuzz-rs](https://github.com/rust-fuzz/honggfuzz-rs)). Without this fuzzers do not reach any interesting code because they cannot generate valid checksums without detailed knowledge about the format, which they do not have.

This already has been used to discover https://github.com/RustAudio/lewton/issues/27