### PR TITLE
Eliminate warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.rs]
+indent_style = tab

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,15 @@ extern crate bytes;
 #[cfg(test)]
 mod test;
 
+macro_rules! tri {
+	($e:expr) => {
+		match $e {
+			Ok(val) => val,
+			Err(err) => return Err(err.into()),
+		}
+	};
+}
+
 mod crc;
 pub mod reading;
 pub mod writing;


### PR DESCRIPTION
I modified the code a little bit so that the code compiles without warnings.  This will help us to detect other unwanted problems early.  I also obeyed some suggestions from `cargo clippy`, except for `-A clippy::redundant_static_lifetimes -A clippy::redundant_field_names -A clippy::println_empty_string`, which is not available in Rust 1.12.0, and four other lints that does not so much worth correcting right away.