### PR TITLE
Simple header search and remove dependency to io::Seek

### DIFF
--- a/src/reading.rs
+++ b/src/reading.rs
@@ -537,13 +537,13 @@ consistent when it encounters the `WouldBlock` error kind.
 If you desire async functionality, consider enabling the `async` feature
 and look into the async module.
 */
-pub struct PacketReader<T :io::Read + io::Seek> {
+pub struct PacketReader<T :io::Read> {
 	rdr :T,
 
 	base_pck_rdr :BasePacketReader,
 }
 
-impl<T :io::Read + io::Seek> PacketReader<T> {
+impl<T :io::Read> PacketReader<T> {
 	/// Constructs a new `PacketReader` with a given `Read`.
 	pub fn new(rdr :T) -> PacketReader<T> {
 		PacketReader { rdr, base_pck_rdr : BasePacketReader::new() }
@@ -628,7 +628,9 @@ impl<T :io::Read + io::Seek> PacketReader<T> {
 
 		Ok(Some(tri!(pg_prs.parse_packet_data(packet_data))))
 	}
+}
 
+impl<T :io::Read + io::Seek> PacketReader<T> {
 	/// Seeks the underlying reader
 	///
 	/// Seeks the reader that this PacketReader bases on by the specified

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -536,6 +536,9 @@ This reader is not async ready. It does not keep its internal state
 consistent when it encounters the `WouldBlock` error kind.
 If you desire async functionality, consider enabling the `async` feature
 and look into the async module.
+
+The reader passed to this packet reader should be buffered properly,
+since `Read::read` will be called many times.
 */
 pub struct PacketReader<T :io::Read> {
 	rdr :T,

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -623,15 +623,15 @@ impl<T :io::Read> PacketReader<T> {
 			};
 			finder.feed(next);
 		}
-		let mut target = &mut ret[4..];
+		let mut pos = 4;
 		loop {
-			let read = tri!(self.rdr.read(target));
+			let read = tri!(self.rdr.read(&mut ret[pos..]));
 			if read == 0 {
 				break;
 			}
-			target = &mut target[read..];
+			pos += read;
 		}
-		if target.is_empty() {
+		if pos == ret.len() {
 			Ok(Some(ret))
 		} else {
 			Ok(None)

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -530,10 +530,10 @@ impl BasePacketReader {
 
 #[derive(Default)]
 struct MagicFinder {
-	len: usize,
+	len :usize,
 }
 impl MagicFinder {
-	fn feed(&mut self, b: u8){
+	fn feed(&mut self, b :u8) {
 		match (b, self.len) {
 			(b'O', _) => self.len = 1,
 			(b'g', 1..=2) | (b'S', 3) => self.len += 1,


### PR DESCRIPTION
closes #12 

I simplified the algorithm of finding the page header.  This method requires a lot of `read()` function called, but the performance degression can be avoided by wrapping the underlying reader with `BufReader` or some other buffering reader.

The algorithm of searching header is intended to be used only for continued sequence of pages.  I am going to introduce another algorithm dedicated for page searching after seek later.