### PR TITLE
Allow access to mutable writer in PacketWriter

### DIFF
--- a/src/writing.rs
+++ b/src/writing.rs
@@ -99,6 +99,9 @@ impl <T :io::Write> PacketWriter<T> {
 	pub fn into_inner(self) -> T {
 		self.wtr
 	}
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.wtr
+    }
 	/// Write a packet
 	///
 	///


### PR DESCRIPTION
Hi - I have a management struct who receives (and seeks) an Ogg source using a PacketReader and rewrite it using a PacketWriter, but it's not exactly like repack. In that case, the result of packet writer must in be some internal memory or an object that must be read by another part of the code who really takes care of moving these packets to destination.

So I created a PacketWriter with a Vec<u8> (buffer) for its 'wtr' and that's fine, it provides the traits for being writable. Unfortunately, this PacketWriter borrows permantely the 'wtr' and I cannot read it anymore. Otherwise, I'd drain() it and shrink_to_fit() nut here data just accumulate.

If I call into_inner, I move out the wtr which is good to let me access the Vec<u8> but not desired as I can't put it back later in the PacketWriter, with the changes I've made. My only option (with my limited Rust understanding) is to borrow 'wtr', drain and empty it and release it after, hence this PR.

This is single thead adn the flow is in a  loop
- Read Packet from an external io::Reader
- Write new Packet using Vec<u8>
- Send data from Vec<u8> somewhere else
- loop

I'm a Rust Noob but I've tried...