### PR TITLE
Let PacketWriter::write_packet use buffers convertible to Cow

### DIFF
--- a/examples/repack.rs
+++ b/examples/repack.rs
@@ -62,7 +62,7 @@ fn run() -> Result<(), std::io::Error> {
 				};
 				let stream_serial = pck.stream_serial();
 				let absgp_page = pck.absgp_page();
-				btry!(pck_wtr.write_packet(pck.data.into_boxed_slice(),
+				btry!(pck_wtr.write_packet(pck.data,
 					stream_serial,
 					inf,
 					absgp_page));

--- a/src/test.rs
+++ b/src/test.rs
@@ -31,9 +31,9 @@ fn test_packet_rw() {
 	{
 		let mut w = PacketWriter::new(&mut c);
 		let np = PacketWriteEndInfo::NormalPacket;
-		w.write_packet(Box::new(test_arr), 0xdeadb33f, np, 0).unwrap();
-		w.write_packet(Box::new(test_arr_2), 0xdeadb33f, np, 1).unwrap();
-		w.write_packet(Box::new(test_arr_3), 0xdeadb33f,
+		w.write_packet(&test_arr[..], 0xdeadb33f, np, 0).unwrap();
+		w.write_packet(&test_arr_2[..], 0xdeadb33f, np, 1).unwrap();
+		w.write_packet(&test_arr_3[..], 0xdeadb33f,
 			PacketWriteEndInfo::EndPage, 2).unwrap();
 	}
 	//print_u8_slice(c.get_ref());
@@ -59,9 +59,9 @@ fn test_packet_rw() {
 	{
 		let mut w = PacketWriter::new(&mut c);
 		let np = PacketWriteEndInfo::NormalPacket;
-		w.write_packet(Box::new(test_arr), 0xdeadb33f, np, 0).unwrap();
-		w.write_packet(Box::new(test_arr_2), 0xdeadb33f, np, 1).unwrap();
-		w.write_packet(Box::new(test_arr_3), 0xdeadb33f,
+		w.write_packet(&test_arr[..], 0xdeadb33f, np, 0).unwrap();
+		w.write_packet(&test_arr_2[..], 0xdeadb33f, np, 1).unwrap();
+		w.write_packet(&test_arr_3[..], 0xdeadb33f,
 			PacketWriteEndInfo::EndPage, 2).unwrap();
 	}
 	//print_u8_slice(c.get_ref());
@@ -86,8 +86,8 @@ fn test_packet_rw() {
 	{
 		let mut w = PacketWriter::new(&mut c);
 		let np = PacketWriteEndInfo::NormalPacket;
-		w.write_packet(Box::new(test_arr_2), 0xdeadb33f, np, 1).unwrap();
-		w.write_packet(Box::new(test_arr_3), 0xdeadb33f,
+		w.write_packet(&test_arr_2[..], 0xdeadb33f, np, 1).unwrap();
+		w.write_packet(&test_arr_3[..], 0xdeadb33f,
 			PacketWriteEndInfo::EndPage, 2).unwrap();
 	}
 	//print_u8_slice(c.get_ref());
@@ -112,10 +112,10 @@ fn test_page_end_after_first_packet() {
 	{
 		let mut w = PacketWriter::new(&mut c);
 		let np = PacketWriteEndInfo::NormalPacket;
-		w.write_packet(Box::new(test_arr), 0xdeadb33f,
+		w.write_packet(&test_arr[..], 0xdeadb33f,
 			PacketWriteEndInfo::EndPage, 0).unwrap();
-		w.write_packet(Box::new(test_arr_2), 0xdeadb33f, np, 1).unwrap();
-		w.write_packet(Box::new(test_arr_3), 0xdeadb33f,
+		w.write_packet(&test_arr_2[..], 0xdeadb33f, np, 1).unwrap();
+		w.write_packet(&test_arr_3[..], 0xdeadb33f,
 			PacketWriteEndInfo::EndPage, 2).unwrap();
 	}
 	//print_u8_slice(c.get_ref());
@@ -153,7 +153,7 @@ fn test_packet_write() {
 
 	{
 		let mut w = PacketWriter::new(&mut c);
-		w.write_packet(Box::new(test_arr_in), 0x5b90a374,
+		w.write_packet(&test_arr_in[..], 0x5b90a374,
 			PacketWriteEndInfo::EndPage, 0).unwrap();
 	}
 	//print_u8_slice(c.get_ref());
@@ -175,11 +175,9 @@ fn test_write_large() {
 	// bytes of payload packet data.
 	// A length of 70_00 will guaranteed create a page break.
 	let test_arr = gen_pck(1234, 70_000 / 4);
-	{
-		let mut w = PacketWriter::new(&mut c);
-		w.write_packet(test_arr.clone(), 0x5b90a374,
-			PacketWriteEndInfo::EndPage, 0).unwrap();
-	}
+	let mut w = PacketWriter::new(&mut c);
+	w.write_packet(&test_arr, 0x5b90a374,
+		PacketWriteEndInfo::EndPage, 0).unwrap();
 	//print_u8_slice(c.get_ref());
 
 	assert_eq!(c.seek(SeekFrom::Start(0)).unwrap(), 0);
@@ -219,7 +217,7 @@ impl XorShift {
 	}
 }
 
-fn gen_pck(seed :u32, len_d_four :usize) -> Box<[u8]> {
+fn gen_pck(seed :u32, len_d_four :usize) -> Vec<u8> {
 	let mut ret = Vec::with_capacity(len_d_four * 4);
 	let mut xs = XorShift::from_two((seed, len_d_four as u32));
 	if len_d_four > 0 {
@@ -235,7 +233,7 @@ fn gen_pck(seed :u32, len_d_four :usize) -> Box<[u8]> {
 		ret.push((v >> 16) as u8);
 		ret.push((v >> 24) as u8);
 	}
-	ret.into_boxed_slice()
+	ret
 }
 
 macro_rules! test_seek_r {
@@ -470,9 +468,9 @@ fn test_issue_14() {
 		c.write_all(&[b'O']).unwrap();
 		let mut w = PacketWriter::new(&mut c);
 		let np = PacketWriteEndInfo::NormalPacket;
-		w.write_packet(Box::new(test_arr), 0xdeadb33f, np, 0).unwrap();
-		w.write_packet(Box::new(test_arr_2), 0xdeadb33f, np, 1).unwrap();
-		w.write_packet(Box::new(test_arr_3), 0xdeadb33f,
+		w.write_packet(&test_arr[..], 0xdeadb33f, np, 0).unwrap();
+		w.write_packet(&test_arr_2[..], 0xdeadb33f, np, 1).unwrap();
+		w.write_packet(&test_arr_3[..], 0xdeadb33f,
 			PacketWriteEndInfo::EndPage, 2).unwrap();
 	}
 	//print_u8_slice(c.get_ref());
@@ -498,9 +496,9 @@ fn test_issue_14() {
 	{
 		let mut w = PacketWriter::new(&mut c);
 		let np = PacketWriteEndInfo::NormalPacket;
-		w.write_packet(Box::new(test_arr), 0xdeadb33f, np, 0).unwrap();
-		w.write_packet(Box::new(test_arr_2), 0xdeadb33f, np, 1).unwrap();
-		w.write_packet(Box::new(test_arr_3), 0xdeadb33f,
+		w.write_packet(&test_arr[..], 0xdeadb33f, np, 0).unwrap();
+		w.write_packet(&test_arr_2[..], 0xdeadb33f, np, 1).unwrap();
+		w.write_packet(&test_arr_3[..], 0xdeadb33f,
 			PacketWriteEndInfo::EndPage, 2).unwrap();
 	}
 	//print_u8_slice(c.get_ref());
@@ -525,8 +523,8 @@ fn test_issue_14() {
 	{
 		let mut w = PacketWriter::new(&mut c);
 		let np = PacketWriteEndInfo::NormalPacket;
-		w.write_packet(Box::new(test_arr_2), 0xdeadb33f, np, 1).unwrap();
-		w.write_packet(Box::new(test_arr_3), 0xdeadb33f,
+		w.write_packet(&test_arr_2[..], 0xdeadb33f, np, 1).unwrap();
+		w.write_packet(&test_arr_3[..], 0xdeadb33f,
 			PacketWriteEndInfo::EndPage, 2).unwrap();
 	}
 	//print_u8_slice(c.get_ref());

--- a/src/writing.rs
+++ b/src/writing.rs
@@ -300,7 +300,7 @@ impl <'writer, T :io::Write> PacketWriter<'writer, T> {
 	}
 }
 
-impl<T :io::Seek + io::Write> PacketWriter<'_, T> {
+impl<'writer, T :io::Seek + io::Write> PacketWriter<'writer, T> {
 	pub fn get_current_offs(&mut self) -> Result<u64, io::Error> {
 		self.wtr.seek(SeekFrom::Current(0))
 	}

--- a/src/writing.rs
+++ b/src/writing.rs
@@ -300,7 +300,7 @@ impl <'writer, T :io::Write> PacketWriter<'writer, T> {
 	}
 }
 
-impl<'writer, T :io::Seek + io::Write> PacketWriter<'writer, T> {
+impl<T :io::Seek + io::Write> PacketWriter<'_, T> {
 	pub fn get_current_offs(&mut self) -> Result<u64, io::Error> {
 		self.wtr.seek(SeekFrom::Current(0))
 	}

--- a/src/writing.rs
+++ b/src/writing.rs
@@ -120,15 +120,15 @@ impl <'writer, T :io::Write> PacketWriter<'writer, T> {
 	///
 	///
 	pub fn write_packet<P: Into<Cow<'writer, [u8]>>>(&mut self, pck_cont :P,
-		serial :u32,
-		inf :PacketWriteEndInfo,
-		/* TODO find a better way to design the API around
-			passing the absgp to the underlying implementation.
-			e.g. the caller passes a closure on init which gets
-			called when we encounter a new page... with the param
-			the index inside the current page, or something.
-		*/
-		absgp :u64) -> IoResult<()> {
+			serial :u32,
+			inf :PacketWriteEndInfo,
+			/* TODO find a better way to design the API around
+				passing the absgp to the underlying implementation.
+				e.g. the caller passes a closure on init which gets
+				called when we encounter a new page... with the param
+				the index inside the current page, or something.
+			*/
+			absgp :u64) -> IoResult<()> {
 		let is_end_stream :bool = inf == PacketWriteEndInfo::EndStream;
 		let pg = self.page_vals.entry(serial).or_insert(
 			CurrentPageValues {

--- a/src/writing.rs
+++ b/src/writing.rs
@@ -10,6 +10,7 @@
 Writing logic
 */
 
+use std::borrow::Cow;
 use std::result;
 use std::io::{self, Cursor, Write, Seek, SeekFrom};
 use byteorder::{WriteBytesExt, LittleEndian};
@@ -29,13 +30,13 @@ Writer for packets into an Ogg stream.
 Note that the functionality of this struct isn't as well tested as for
 the `PacketReader` struct.
 */
-pub struct PacketWriter<T :io::Write> {
+pub struct PacketWriter<'writer, T :io::Write> {
 	wtr :T,
 
-	page_vals :HashMap<u32, CurrentPageValues>,
+	page_vals :HashMap<u32, CurrentPageValues<'writer>>,
 }
 
-struct CurrentPageValues {
+struct CurrentPageValues<'writer> {
 	/// `true` if this page is the first one in the logical bitstream
 	first_page :bool,
 	/// Page counter of the current page
@@ -46,7 +47,7 @@ struct CurrentPageValues {
 	segment_cnt :u8,
 	cur_pg_lacing :[u8; 255],
 	/// The data and the absgp's of the packets
-	cur_pg_data :Vec<(Box<[u8]>, u64)>,
+	cur_pg_data :Vec<(Cow<'writer, [u8]>, u64)>,
 
 	/// Some(offs), if the last packet
 	/// couldn't make it fully into this page, and
@@ -89,7 +90,7 @@ pub enum PacketWriteEndInfo {
 	EndStream,
 }
 
-impl <T :io::Write> PacketWriter<T> {
+impl <'writer, T :io::Write> PacketWriter<'writer, T> {
 	pub fn new(wtr :T) -> Self {
 		return PacketWriter {
 			wtr,
@@ -118,15 +119,16 @@ impl <T :io::Write> PacketWriter<T> {
 	/// Write a packet
 	///
 	///
-	pub fn write_packet(&mut self, pck_cont :Box<[u8]>, serial :u32,
-			inf :PacketWriteEndInfo,
-			/* TODO find a better way to design the API around
-				passing the absgp to the underlying implementation.
-				e.g. the caller passes a closure on init which gets
-				called when we encounter a new page... with the param
-				the index inside the current page, or something.
-			*/
-			absgp :u64) -> IoResult<()> {
+	pub fn write_packet<P: Into<Cow<'writer, [u8]>>>(&mut self, pck_cont :P,
+		serial :u32,
+		inf :PacketWriteEndInfo,
+		/* TODO find a better way to design the API around
+			passing the absgp to the underlying implementation.
+			e.g. the caller passes a closure on init which gets
+			called when we encounter a new page... with the param
+			the index inside the current page, or something.
+		*/
+		absgp :u64) -> IoResult<()> {
 		let is_end_stream :bool = inf == PacketWriteEndInfo::EndStream;
 		let pg = self.page_vals.entry(serial).or_insert(
 			CurrentPageValues {
@@ -140,6 +142,7 @@ impl <T :io::Write> PacketWriter<T> {
 			}
 		);
 
+		let pck_cont = pck_cont.into();
 		let cont_len = pck_cont.len();
 		pg.cur_pg_data.push((pck_cont, absgp));
 
@@ -297,7 +300,7 @@ impl <T :io::Write> PacketWriter<T> {
 	}
 }
 
-impl<T :io::Seek + io::Write> PacketWriter<T> {
+impl<T :io::Seek + io::Write> PacketWriter<'_, T> {
 	pub fn get_current_offs(&mut self) -> Result<u64, io::Error> {
 		self.wtr.seek(SeekFrom::Current(0))
 	}
@@ -321,13 +324,13 @@ fn test_recapture() {
 		let ep = PacketWriteEndInfo::EndPage;
 		{
 			let mut w = PacketWriter::new(&mut c);
-			w.write_packet(Box::new(test_arr), 0xdeadb33f, ep, 0).unwrap();
+			w.write_packet(&test_arr[..], 0xdeadb33f, ep, 0).unwrap();
 
 			// Now, after the end of the page, put in some noise.
 			w.wtr.write_all(&[0; 38]).unwrap();
 
-			w.write_packet(Box::new(test_arr_2), 0xdeadb33f, np, 1).unwrap();
-			w.write_packet(Box::new(test_arr_3), 0xdeadb33f, ep, 2).unwrap();
+			w.write_packet(&test_arr_2[..], 0xdeadb33f, np, 1).unwrap();
+			w.write_packet(&test_arr_3[..], 0xdeadb33f, ep, 2).unwrap();
 		}
 	}
 	//print_u8_slice(c.get_ref());

--- a/tests/async_read.rs
+++ b/tests/async_read.rs
@@ -16,7 +16,6 @@ extern crate futures;
 use std::io;
 use ogg::{PacketWriter, PacketWriteEndInfo};
 use ogg::reading::async_api::PacketReader;
-use std::boxed::Box;
 use std::io::{Cursor, Seek, SeekFrom};
 use tokio_io::AsyncRead;
 use futures::Stream;
@@ -74,9 +73,9 @@ fn test_ogg_random_would_block_run() {
 	{
 		let mut w = PacketWriter::new(&mut c);
 		let np = PacketWriteEndInfo::NormalPacket;
-		w.write_packet(Box::new(test_arr), 0xdeadb33f, np, 0).unwrap();
-		w.write_packet(Box::new(test_arr_2), 0xdeadb33f, np, 1).unwrap();
-		w.write_packet(Box::new(test_arr_3), 0xdeadb33f,
+		w.write_packet(&test_arr[..], 0xdeadb33f, np, 0).unwrap();
+		w.write_packet(&test_arr_2[..], 0xdeadb33f, np, 1).unwrap();
+		w.write_packet(&test_arr_3[..], 0xdeadb33f,
 			PacketWriteEndInfo::EndPage, 2).unwrap();
 	}
 	//print_u8_slice(c.get_ref());
@@ -103,9 +102,9 @@ fn test_ogg_random_would_block_run() {
 	{
 		let mut w = PacketWriter::new(&mut c);
 		let np = PacketWriteEndInfo::NormalPacket;
-		w.write_packet(Box::new(test_arr), 0xdeadb33f, np, 0).unwrap();
-		w.write_packet(Box::new(test_arr_2), 0xdeadb33f, np, 1).unwrap();
-		w.write_packet(Box::new(test_arr_3), 0xdeadb33f,
+		w.write_packet(&test_arr[..], 0xdeadb33f, np, 0).unwrap();
+		w.write_packet(&test_arr_2[..], 0xdeadb33f, np, 1).unwrap();
+		w.write_packet(&test_arr_3[..], 0xdeadb33f,
 			PacketWriteEndInfo::EndPage, 2).unwrap();
 	}
 	//print_u8_slice(c.get_ref());
@@ -131,8 +130,8 @@ fn test_ogg_random_would_block_run() {
 	{
 		let mut w = PacketWriter::new(&mut c);
 		let np = PacketWriteEndInfo::NormalPacket;
-		w.write_packet(Box::new(test_arr_2), 0xdeadb33f, np, 1).unwrap();
-		w.write_packet(Box::new(test_arr_3), 0xdeadb33f,
+		w.write_packet(&test_arr_2[..], 0xdeadb33f, np, 1).unwrap();
+		w.write_packet(&test_arr_3[..], 0xdeadb33f,
 			PacketWriteEndInfo::EndPage, 2).unwrap();
 	}
 	//print_u8_slice(c.get_ref());


### PR DESCRIPTION
As pointed out in issue #19, in some cases it may not be desirable to heap allocate Ogg packet contents, but the current parameters of the `write_packet` method impose a heap allocation no matter what.

However, the `PacketWriter` struct doesn't actually need to own the packet data, as long as it stays in memory unmodified during its lifetime. The `Cow` smart pointer that the standard library provides captures this requirement more precisely, and provides for more elegant, flexible and potentially efficient client code.

Therefore, substitute `Box` for `Cow` in the aforementioned code. Boxed slices can still be used with this new design, although with a different syntax, which breaks backwards compatibility.