### PR TITLE
Add the async API to the documentation generated by docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,7 @@ tokio = { version = "1", features = ["full"] }
 
 [features]
 async = ["tokio", "tokio-util", "futures-util", "bytes", "pin-project"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-## Ogg
+## Ogg [![docs.rs documentation](https://img.shields.io/docsrs/ogg?label=docs.rs)](https://docs.rs/ogg/latest)
 
 An Ogg decoder and encoder. Implements the [xiph.org Ogg spec](https://www.xiph.org/vorbis/doc/framing.html) in pure Rust.
-
-[Documentation](https://docs.rs/ogg/0.8.0).
 
 If the `async` feature is disabled, Version 1.56.1 of Rust is the minimum supported one.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
 #![allow(clippy::tabs_in_doc_comments)]
 #![allow(clippy::new_without_default)]
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 /*!
 Ogg container decoder and encoder
 


### PR DESCRIPTION
Currently, the documentation available at docs.rs for this crate does not mention the feature-gated async API at all, which makes it harder for users to discover it. I think everyone can agree that documenting it better is a good thing.

However, documenting feature-gated APIs is not that straightforward. The naive approach of passing `--all-features` to `cargo doc` generates documentation that does not mention under which conditions feature-gated APIs are available. [An unstable rustdoc feature addresses that problem](https://doc.rust-lang.org/nightly/rustdoc/unstable-features.html#doccfg-recording-what-platforms-or-features-are-required-for-code-to-be-present), but unconditionally enabling it means that the project can no longer be developed on a stable Rust toolchain.

As a compromise but fairly elegant solution, exploit the fact that docs.rs generates the documentation that most end-users will consume: docs.rs [uses a nightly toolchain](https://docs.rs/about/builds) and [allows setting conditional compilation options in the Cargo manifest](https://docs.rs/about/metadata) to only enable unstable rustdoc features in that environment, so the usual development workflow is entirely unaffected.

People interested in building their own documentation that looks exactly like the one that would be generated by docs.rs can replicate the relevant docs.rs environment configuration easily. The following command does that:

```
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
```

While at it, change the documentation link in the README to use a prettier badge.

The following screenshots show how the new documentation sections would look.

![image](https://user-images.githubusercontent.com/7822554/164892160-f55834ce-407a-480e-994e-07e38688dd76.png)
---
![image](https://user-images.githubusercontent.com/7822554/164892226-abde2e0c-6e07-4ecb-b884-0aab1d2a00f8.png)
---
![image](https://user-images.githubusercontent.com/7822554/164892238-72f34bd4-fd47-4a67-bd70-be11506401f5.png)
