### PR TITLE
Allow instantiating async `PacketReader` with a futures `AsyncRead`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,10 @@ name = "ogg"
 
 [dependencies]
 byteorder = "1.0"
+futures-core = { version = "0.3", optional = true }
+futures-io = { version = "0.3", optional = true }
 tokio = { version = "1", optional = true }
-tokio-util = { version = "0.6", features = ["codec"], optional = true }
-futures-util = { version = "0.3", features = ["io"], optional = true }
+tokio-util = { version = "0.6", features = ["codec", "compat"], optional = true }
 bytes = { version = "1", optional = true }
 pin-project = { version = "1", optional = true }
 
@@ -27,7 +28,7 @@ rand = "0.8"
 tokio = { version = "1", features = ["full"] }
 
 [features]
-async = ["tokio", "tokio-util", "futures-util", "bytes", "pin-project"]
+async = ["futures-core", "futures-io", "tokio", "tokio-util", "bytes", "pin-project"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ pin-project = { version = "1", optional = true }
 [dev-dependencies]
 rand = "0.8"
 tokio = { version = "1", features = ["full"] }
+futures-util = "0.3"
 
 [features]
 async = ["futures-core", "futures-io", "tokio", "tokio-util", "bytes", "pin-project"]

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -1133,8 +1133,10 @@ pub mod async_api {
 
 	impl<T :TokioAsyncRead> PacketReader<T> {
 		/// Wraps the specified Tokio runtime `AsyncRead` into an Ogg packet
-		/// reader. This is the recommended constructor when using the Tokio
-		/// runtime types.
+		/// reader.
+		///
+		/// This is the recommended constructor when using the Tokio runtime
+		/// types.
 		pub fn new(inner :T) -> Self {
 			PacketReader {
 				base_pck_rdr : BasePacketReader::new(),
@@ -1145,11 +1147,13 @@ pub mod async_api {
 
 	impl<T :FuturesAsyncRead> PacketReader<Compat<T>> {
 		/// Wraps the specified futures_io `AsyncRead` into an Ogg packet
-		/// reader. This crate uses Tokio internally, so a wrapper that
-		/// may have some performance cost will be used. Therefore, this
-		/// constructor is to be used only when dealing with `AsyncRead`
-		/// implementations from other runtimes, and implementing a Tokio
-		/// `AsyncRead` compatibility layer oneself is not desired.
+		/// reader.
+		///
+		/// This crate uses Tokio internally, so a wrapper that may have
+		/// some performance cost will be used. Therefore, this constructor
+		/// is to be used only when dealing with `AsyncRead` implementations
+		/// from other runtimes, and implementing a Tokio `AsyncRead`
+		/// compatibility layer oneself is not desired.
 		pub fn new_compat(inner :T) -> Self {
 			Self::new(inner.compat())
 		}

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -1033,11 +1033,13 @@ pub mod async_api {
 	use std::task::{Context, Poll};
 
 	use super::*;
+	use futures_core::{ready, Stream};
+	use futures_io::AsyncRead as FuturesAsyncRead;
+	use tokio::io::AsyncRead as TokioAsyncRead;
 	use bytes::BytesMut;
-	use futures_util::{ready, Stream};
 	use pin_project::pin_project;
-	use tokio::io::AsyncRead;
 	use tokio_util::codec::{Decoder, FramedRead};
+	use tokio_util::compat::{Compat, FuturesAsyncReadCompatExt};
 
 	enum PageDecodeState {
 		Head,
@@ -1123,13 +1125,16 @@ pub mod async_api {
 	Async packet reading functionality.
 	*/
 	#[pin_project]
-	pub struct PacketReader<T> where T :AsyncRead {
+	pub struct PacketReader<T> where T :TokioAsyncRead {
 		base_pck_rdr :BasePacketReader,
 		#[pin]
 		pg_rd :FramedRead<T, PageDecoder>,
 	}
 
-	impl<T :AsyncRead> PacketReader<T> {
+	impl<T :TokioAsyncRead> PacketReader<T> {
+		/// Wraps the specified Tokio runtime `AsyncRead` into an Ogg packet
+		/// reader. This is the recommended constructor when using the Tokio
+		/// runtime types.
 		pub fn new(inner :T) -> Self {
 			PacketReader {
 				base_pck_rdr : BasePacketReader::new(),
@@ -1138,7 +1143,19 @@ pub mod async_api {
 		}
 	}
 
-	impl<T :AsyncRead> Stream for PacketReader<T> {
+	impl<T :FuturesAsyncRead> PacketReader<Compat<T>> {
+		/// Wraps the specified futures_io `AsyncRead` into an Ogg packet
+		/// reader. This crate uses Tokio internally, so a wrapper that
+		/// may have some performance cost will be used. Therefore, this
+		/// constructor is to be used only when dealing with `AsyncRead`
+		/// implementations from other runtimes, and implementing a Tokio
+		/// `AsyncRead` compatibility layer oneself is not desired.
+		pub fn new_compat(inner :T) -> Self {
+			Self::new(inner.compat())
+		}
+	}
+
+	impl<T :TokioAsyncRead> Stream for PacketReader<T> {
 		type Item = Result<Packet, OggReadError>;
 
 		fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {


### PR DESCRIPTION
The async `PacketReader` struct is implemented using `tokio`, which nowadays is the _de facto_ standard async runtime in the Rust ecosystem. However, other async runtimes exist, such as `async-std` and `smol`. People may want to use these alternatives for a variety of reasons.

This internal dependency on Tokio is noticeable to end-users of the async `PacketReader` struct: they need to pass a Tokio `AsyncRead` no matter what, even though each async runtime has its own similar, but not quite the same implementation of the `AsyncRead` trait.

The futures crate [is said to contain types meant to be interoperable and maybe eventually integrated in the Rust standard library](https://rust-lang.github.io/async-book/08_ecosystem/00_chapter.html#the-futures-crate), so accepting its implementation of `AsyncRead` looks like the most compatible choice across the whole async ecosystem. It also is easier for end-users to wrap whatever incompatible `AsyncRead` they might be using to a futures `AsyncRead`: depending on the futures crate is more lightweight and feels more like "neutral ground".

Therefore, add a new compatibility constructor for `PacketReader` that accepts a futures `AsyncRead`, and then uses the Tokio compatibility layer to get a Tokio `AsyncRead` from it. I think it's best to not drop the previous Tokio `AsyncRead` constructor for two reasons:

- As the Tokio runtime is the _de facto_ standard, it is reasonable to care about the ergonomics of using its `AsyncRead`s. Tokio offers a compatibility layer to go from its `AsyncRead` to the futures `AsyncRead`, but asking client code to use it is more cumbersome and a breaking API change.
- The compatibility layer may have a small performance penalty due to Tokio no longer being able to safely assume some invariants that its implementations of the `AsyncRead` trait hold.

While at it, refactor the `futures` crate dependency a bit to depend on smaller subcrates, which reduces the total number of transitive dependencies pulled when building.