### PR TITLE
Add async PacketWriter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ name = "ogg"
 [dependencies]
 byteorder = "1.0"
 futures-core = { version = "0.3", optional = true }
+futures-sink = { version = "0.3", optional = true }
 futures-io = { version = "0.3", optional = true }
 tokio = { version = "1", optional = true }
 tokio-util = { version = "0.6", features = ["codec", "compat"], optional = true }
@@ -29,7 +30,7 @@ tokio = { version = "1", features = ["full"] }
 futures-util = "0.3"
 
 [features]
-async = ["futures-core", "futures-io", "tokio", "tokio-util", "bytes", "pin-project"]
+async = ["futures-core", "futures-sink", "futures-io", "tokio", "tokio-util", "bytes", "pin-project"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Given that this crate already supports async reads, it makes sense to complete its async support for writes for API parity.

To achieve this addition the packet writing logic was extracted to a new private struct, `BasePacketWriter`, that is largely the same as before, with the exception of some refactors to delete data from ended streams of the map, which was a TODO comment, and getting rid of byteorder and fallible I/O operations. This new struct is not responsible for doing any I/O: it just invokes a callback, which can return `false` to indicate a failure and stop the writing process.

The blocking `PacketWriter` now uses `BasePacketWriter` with a callback that writes everything to the sink as before. Any error that might happen is stored and returned with the same user-visible behavior as before.

The new async `PacketWriter` is pretty trivial thanks to Tokio encoders and the usage of callbacks by `BasePacketWriter`, as it is possible to simply copy any written pages to a Tokio-provided buffer, which always succeeds. Tokio takes care of all the dirty details of actual I/O.