### PR TITLE
Do not return error on garbage data after last Ogg page

### DIFF
--- a/src/reading.rs
+++ b/src/reading.rs
@@ -779,8 +779,8 @@ impl<T :io::Read + io::Seek> PacketReader<T> {
 			res = match res {
 				Eof => return Ok(None),
 				Found => {
-					// Keep track whether a page was read to distinguish empty
-					// files from non-Ogg files at read_ogg_page.
+					// Keep track whether a page was read to distinguish non-Ogg
+					// files from Ogg files with trailing junk at read_ogg_page.
 					self.read_some_pg = true;
 					break
 				},

--- a/src/test.rs
+++ b/src/test.rs
@@ -560,6 +560,8 @@ fn test_issue_7() {
 		let mut r = PacketReader::new(c);
 		let p1 = r.read_packet().unwrap().unwrap();
 		assert_eq!(test_arr, *p1.data);
+		// Make sure we don't yield the trailing garbage.
+		assert!(r.read_packet().unwrap().is_none());
 	}
 
 	// Non-Ogg data should return an error.

--- a/src/test.rs
+++ b/src/test.rs
@@ -8,7 +8,7 @@
 
 use super::*;
 
-use std::io::{Cursor, Seek, SeekFrom};
+use std::io::{Cursor, Seek, SeekFrom, Write};
 
 macro_rules! test_arr_eq {
 	($a_arr:expr, $b_arr:expr) => {
@@ -464,7 +464,6 @@ fn test_issue_14() {
 	let test_arr_2 = [2, 4, 8, 16, 32, 64, 128, 127, 126, 125, 124];
 	let test_arr_3 = [3, 5, 9, 17, 33, 65, 129, 129, 127, 126, 125];
 	{
-		use std::io::Write;
 		c.write_all(&[b'O']).unwrap();
 		let mut w = PacketWriter::new(&mut c);
 		let np = PacketWriteEndInfo::NormalPacket;
@@ -535,5 +534,45 @@ fn test_issue_14() {
 		test_arr_eq!(test_arr_2, *p2.data);
 		let p3 = r.read_packet().unwrap().unwrap();
 		assert_eq!(test_arr_3, *p3.data);
+	}
+}
+
+// Regression test for issue 7:
+// Ignore junk after the last Ogg page, while ensuring that non-Ogg
+// data is treated as invalid.
+#[test]
+fn test_issue_7() {
+	let mut c = Cursor::new(Vec::new());
+	let test_arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+	let test_arr_2 = [2, 4, 8, 16, 32, 64, 128, 127, 126, 125, 124];
+	{
+		let mut w = PacketWriter::new(&mut c);
+		w.write_packet(&test_arr[..], 0xdeadb33f,
+			PacketWriteEndInfo::EndStream, 0).unwrap();
+	}
+	// Write trailing garbage.
+	c.write_all(&test_arr_2[..]).unwrap();
+	//print_u8_slice(c.get_ref());
+
+	// Trailing garbage should be ignored.
+	assert_eq!(c.seek(SeekFrom::Start(0)).unwrap(), 0);
+	{
+		let mut r = PacketReader::new(c);
+		let p1 = r.read_packet().unwrap().unwrap();
+		assert_eq!(test_arr, *p1.data);
+	}
+
+	// Non-Ogg data should return an error.
+	let c = Cursor::new(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+	{
+		let mut r = PacketReader::new(c);
+		assert!(matches!(r.read_packet(), Err(OggReadError::NoCapturePatternFound)));
+	}
+
+	// Empty data is considered non-Ogg data.
+	let c = Cursor::new(&[]);
+	{
+		let mut r = PacketReader::new(c);
+		assert!(matches!(r.read_packet(), Err(OggReadError::NoCapturePatternFound)));
 	}
 }


### PR DESCRIPTION
Some admittedly badly-encoded Ogg Vorbis files in the wild contain trailing garbage data after the last Ogg page, such as this one: https://freesound.org/people/stomachache/sounds/157587/

The page reading code explicitly handled this case by returning an error, which makes sense to do given that the Ogg specification is not clear on how this condition should be dealt with. Moreover, programs like `ogginfo` also show warnings for these kind of files. However, being this strict causes codec crates that depend on this one to not be able to play back such files properly, as discussed in https://github.com/RustAudio/ogg/issues/7.

Fix the situation by being more lenient with this nonsense. Some additional status information is kept to distinguish this case from empty files.

I've not tested the seeking code thoroughly after these changes, but both empty, normal and normal but with trailing garbage files seem to work fine. Tests also pass.