### PR TITLE
Add method to retrieve the checksum of the end page for a `Packet`

### DIFF
--- a/.github/workflows/ogg.yml
+++ b/.github/workflows/ogg.yml
@@ -19,6 +19,9 @@ jobs:
       with:
         toolchain: ${{ matrix.toolchain }}
         override: true
+    - name: Downgrade dependencies to comply with MSRV
+      if: matrix.toolchain == '1.56.1'
+      run: cargo update -p tokio --precise 1.29.1
     - name: Run no-default-features builds
       if: matrix.toolchain != '1.56.1'
       run: |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,8 @@ pub struct Packet {
 	absgp_page :u64,
 	/// Serial number. Uniquely identifying the logical bitstream.
 	stream_serial :u32,
+	/// Checksum of the last page the packet was in.
+	checksum_page :u32,
 	/*/// Packet counter
 	/// Why u64? There are MAX_U32 pages, and every page has up to 128 packets. u32 wouldn't be sufficient here...
 	pub sequence_num :u64,*/ // TODO perhaps add this later on...
@@ -97,5 +99,9 @@ impl Packet {
 	/// Returns the serial number that uniquely identifies the logical bitstream.
 	pub fn stream_serial(&self) -> u32 {
 		self.stream_serial
+	}
+	/// Returns the checksum of the page the packet ended in.
+	pub fn checksum_page(&self) -> u32 {
+		self.checksum_page
 	}
 }

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -89,6 +89,8 @@ struct PageBaseInfo {
 	absgp :u64,
 	/// Page counter
 	sequence_num :u32,
+	/// Page checksum
+	checksum :u32,
 	/// Packet information:
 	/// index is number of packet,
 	/// tuple is (offset, length) of packet
@@ -210,6 +212,7 @@ impl PageParser {
 				last_page : header_type_flag & 0x04u8 != 0,
 				absgp,
 				sequence_num,
+				checksum,
 				packet_positions : Vec::new(),
 				ends_with_continued : false,
 			},
@@ -411,6 +414,7 @@ impl BasePacketReader {
 			last_packet_pg: last_pck_in_pg,
 			last_packet_stream: last_pck_overall,
 			absgp_page: pg_info.bi.absgp,
+			checksum_page: pg_info.bi.checksum,
 			stream_serial: str_serial,
 		});
 	}


### PR DESCRIPTION
The Ogg specification demands that each Ogg page has a checksum of its data for error detection and correction purposes. Logically, this checksum is an implementation detail of the Ogg transport, and higher-level decoders need not know it to parse logical bitstreams. However, specialized decoders may want to efficiently use it to compute a checksum of the data that flows through it, avoiding hashing packet data again ([this is my concrete use case for that](https://github.com/OptiVorbis/OptiVorbis/commit/81db11771c082af647d9f791ecdf3ddac9c4a549)). In addition, testing code may also find use in a checksum to assert that the data of the page a packet belongs to is reasonably similar to what's expected.

Given that the Ogg parsing code already reads and compares page checksums, exposing them in the public `Packet` API, which already allows users to retrieve Ogg encapsulation data such as the granule position, comes at practically no additional cost.