### PR TITLE
Make page CRC verification toggleable by end-users

### DIFF
--- a/.github/workflows/ogg.yml
+++ b/.github/workflows/ogg.yml
@@ -21,7 +21,9 @@ jobs:
         override: true
     - name: Downgrade dependencies to comply with MSRV
       if: matrix.toolchain == '1.56.1'
-      run: cargo update -p tokio --precise 1.29.1
+      run: |
+        cargo update -p tokio --precise 1.29.1
+        cargo update -p ppv-lite86 --precise 0.2.17
     - name: Run no-default-features builds
       if: matrix.toolchain != '1.56.1'
       run: |

--- a/.github/workflows/ogg.yml
+++ b/.github/workflows/ogg.yml
@@ -24,6 +24,9 @@ jobs:
       run: |
         cargo test --verbose --no-default-features
         cargo doc --verbose --no-default-features
+    - name: Downgrade dependencies to comply with MSRV
+      if: matrix.toolchain == '1.61'
+      run: cargo update -p tokio --precise 1.29.1
     - name: Run no-default-features builds (forbidding warnings)
       if: matrix.toolchain == '1.61'
       env:

--- a/.github/workflows/ogg.yml
+++ b/.github/workflows/ogg.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        toolchain: [stable, beta, 1.56.1]
+        toolchain: [stable, beta, 1.61]
 
     runs-on: ${{ matrix.os }}
 
@@ -19,25 +19,20 @@ jobs:
       with:
         toolchain: ${{ matrix.toolchain }}
         override: true
-    - name: Downgrade dependencies to comply with MSRV
-      if: matrix.toolchain == '1.56.1'
-      run: |
-        cargo update -p tokio --precise 1.29.1
-        cargo update -p ppv-lite86 --precise 0.2.17
     - name: Run no-default-features builds
-      if: matrix.toolchain != '1.56.1'
+      if: matrix.toolchain != '1.61'
       run: |
         cargo test --verbose --no-default-features
         cargo doc --verbose --no-default-features
     - name: Run no-default-features builds (forbidding warnings)
-      if: matrix.toolchain == '1.56.1'
+      if: matrix.toolchain == '1.61'
       env:
         RUSTFLAGS: -D warnings
       run: |
         cargo test --verbose --no-default-features
         cargo doc --verbose --no-default-features
     - name: Run all-features builds
-      if: matrix.toolchain != '1.56.1'
+      if: matrix.toolchain != '1.61'
       run: |
         cargo test --verbose --all-features
         cargo doc --verbose --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,6 @@ async = ["futures-core", "futures-io", "tokio", "tokio-util", "bytes", "pin-proj
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["ogg", "decoder", "encoder", "xiph"]
 documentation = "https://docs.rs/ogg/0.8.0"
 repository = "https://github.com/RustAudio/ogg"
 readme = "README.md"
-rust-version = "1.56.0"
+rust-version = "1.61.0"
 
 [lib]
 name = "ogg"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An Ogg decoder and encoder. Implements the [xiph.org Ogg spec](https://www.xiph.org/vorbis/doc/framing.html) in pure Rust.
 
-If the `async` feature is disabled, Version 1.56.1 of Rust is the minimum supported one.
+If the `async` feature is disabled, Version 1.61 of Rust is the minimum supported one.
 
 Note: `.ogg` files are vorbis encoded audio files embedded into an Ogg transport stream.
 There is no extra support for vorbis codec decoding or encoding in this crate,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub mod reading;
 pub mod writing;
 
 pub use crate::writing::{PacketWriter, PacketWriteEndInfo};
-pub use crate::reading::{PacketReader, OggReadError};
+pub use crate::reading::{PacketReader, OggReadError, PageParsingOptions};
 
 /**
 Ogg packet representation.

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -1235,7 +1235,7 @@ pub mod async_api {
 		/// from other runtimes, and implementing a Tokio `AsyncRead`
 		/// compatibility layer oneself is not desired.
 		pub fn new_compat(inner :T) -> Self {
-			Self::new_compat_with_page_parse_opts(inner.compat(), PageParsingOptions::default())
+			Self::new_compat_with_page_parse_opts(inner, PageParsingOptions::default())
 		}
 
 		/// Wraps the specified futures_io `AsyncRead` into an Ogg packet


### PR DESCRIPTION
These changes make the Ogg page CRC verification check toggleable at runtime by end-users via a new `PageParsingOptions` struct that may be passed at reader/parser construction time. I have paid special attention to making the new feature both backwards and forwards compatible, which led me to taking the following design choices:

- No signature of any existing public method was modified. People looking into changing parsing behavior via the new `PageParsingOptions` struct must use the new `*_with_parse_opts` methods.
- Marking `PageParsingOptions` as `#[non_exhaustive]`, so that we may add new public fields to it in the future without a semver-breaking change. Users must always default-initialize this struct. It only derives `Clone` too, in case we ever need to make it hold non-`Copy` types.
- Shared ownership of the `PageParsingOptions` between different reader structs is achieved through `Arc`s, which ensures that no struct stops being `Send` or `Sync` with a negligble performance impact.

The `fuzzing` cfg flag is still honored after these changes by using it to set a default value for the new `verify_checksum` page parsing option accordingly.

The need for these changes has been brought forward in https://github.com/OptiVorbis/OptiVorbis/issues/101.